### PR TITLE
Add Notify=healthy to quadlet

### DIFF
--- a/quadlet/scoutzknivez.container
+++ b/quadlet/scoutzknivez.container
@@ -16,6 +16,7 @@ Environment=BOTS=1
 DropCapability=ALL
 NoNewPrivileges=true
 StopTimeout=50
+Notify=healthy
 
 [Service]
 Restart=on-failure


### PR DESCRIPTION
## Summary
- Add `Notify=healthy` to scoutzknivez quadlet so systemd waits for the image's built-in HEALTHCHECK to pass before marking the service as started

## Test plan
- [ ] `systemctl --user daemon-reload` and restart scoutzknivez
- [ ] Verify with `systemctl --user status scoutzknivez`

🤖 Generated with [Claude Code](https://claude.com/claude-code)